### PR TITLE
Phase 4 (v0.4.0): Suggestion Algorithm and Schedules

### DIFF
--- a/web/app/api/schedules/[id]/__tests__/route.test.ts
+++ b/web/app/api/schedules/[id]/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+/** @jest-environment node */
+
+import { Prisma } from '@prisma/client'
+import { DELETE } from '../route'
+import { db } from '@/lib/db'
+import { requireApprovedUser } from '@/lib/auth/require-approval'
+
+jest.mock('@/lib/auth/require-approval', () => ({
+  requireApprovedUser: jest.fn(),
+}))
+
+jest.mock('@/lib/db', () => ({
+  db: {
+    schedule: {
+      delete: jest.fn(),
+    },
+  },
+}))
+
+type MockDb = {
+  schedule: {
+    delete: jest.Mock
+  }
+}
+
+const mockDb = db as unknown as MockDb
+const mockRequireApprovedUser = requireApprovedUser as jest.Mock
+
+describe('/api/schedules/[id]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRequireApprovedUser.mockResolvedValue({ user: { id: 'user-1' } })
+  })
+
+  it('deletes schedule', async () => {
+    mockDb.schedule.delete.mockResolvedValue({ id: 'schedule-1' })
+
+    const response = await DELETE(new Request('http://localhost/api/schedules/schedule-1', { method: 'DELETE' }), {
+      params: Promise.resolve({ id: 'schedule-1' }),
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.success).toBe(true)
+  })
+
+  it('returns 404 when schedule does not exist', async () => {
+    const prismaError = new Prisma.PrismaClientKnownRequestError('Not found', {
+      code: 'P2025',
+      clientVersion: '7.3.0',
+    })
+    mockDb.schedule.delete.mockRejectedValue(prismaError)
+
+    const response = await DELETE(new Request('http://localhost/api/schedules/missing', { method: 'DELETE' }), {
+      params: Promise.resolve({ id: 'missing' }),
+    })
+    const body = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(body.error).toContain('not found')
+  })
+})

--- a/web/app/api/schedules/[id]/route.ts
+++ b/web/app/api/schedules/[id]/route.ts
@@ -1,0 +1,31 @@
+import { Prisma } from '@prisma/client'
+import { requireApprovedUser } from '@/lib/auth/require-approval'
+import { db } from '@/lib/db'
+
+interface RouteContext {
+  params: Promise<{ id: string }>
+}
+
+export async function DELETE(_request: Request, context: RouteContext) {
+  await requireApprovedUser()
+
+  const { id } = await context.params
+  if (!id) {
+    return Response.json({ error: 'Schedule ID is required' }, { status: 400 })
+  }
+
+  try {
+    await db.schedule.delete({
+      where: { id },
+    })
+
+    return Response.json({ success: true })
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2025') {
+      return Response.json({ error: 'Schedule not found' }, { status: 404 })
+    }
+
+    console.error('Failed to delete schedule:', error)
+    return Response.json({ error: 'Failed to delete schedule' }, { status: 500 })
+  }
+}

--- a/web/app/api/schedules/__tests__/route.test.ts
+++ b/web/app/api/schedules/__tests__/route.test.ts
@@ -1,0 +1,182 @@
+/** @jest-environment node */
+
+import { Frequency } from '@prisma/client'
+import { GET, POST } from '../route'
+import { db } from '@/lib/db'
+import { requireApprovedUser } from '@/lib/auth/require-approval'
+import { getSuggestedChoreForSlot, isChoreCompatibleWithSlot } from '@/lib/suggestions'
+
+jest.mock('@/lib/auth/require-approval', () => ({
+  requireApprovedUser: jest.fn(),
+}))
+
+jest.mock('@/lib/suggestions', () => ({
+  getSuggestedChoreForSlot: jest.fn(),
+  isChoreCompatibleWithSlot: jest.fn(),
+}))
+
+jest.mock('@/lib/db', () => ({
+  db: {
+    schedule: {
+      findMany: jest.fn(),
+      create: jest.fn(),
+    },
+    chore: {
+      findUnique: jest.fn(),
+    },
+  },
+}))
+
+type MockDb = {
+  schedule: {
+    findMany: jest.Mock
+    create: jest.Mock
+  }
+  chore: {
+    findUnique: jest.Mock
+  }
+}
+
+const mockDb = db as unknown as MockDb
+const mockRequireApprovedUser = requireApprovedUser as jest.Mock
+const mockGetSuggestedChoreForSlot = getSuggestedChoreForSlot as jest.Mock
+const mockIsChoreCompatibleWithSlot = isChoreCompatibleWithSlot as jest.Mock
+
+describe('/api/schedules', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRequireApprovedUser.mockResolvedValue({ user: { id: 'user-1' } })
+    mockIsChoreCompatibleWithSlot.mockReturnValue(true)
+  })
+
+  it('GET validates from date', async () => {
+    const response = await GET(new Request('http://localhost/api/schedules?from=invalid'))
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toContain('Invalid from date')
+  })
+
+  it('GET returns schedules', async () => {
+    mockDb.schedule.findMany.mockResolvedValue([
+      {
+        id: 'schedule-1',
+        choreId: 'chore-1',
+        slotType: Frequency.WEEKLY,
+        scheduledFor: new Date('2025-01-10T00:00:00.000Z'),
+      },
+    ])
+
+    const response = await GET(new Request('http://localhost/api/schedules?slotType=WEEKLY&limit=5'))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.data).toHaveLength(1)
+    expect(mockDb.schedule.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ slotType: Frequency.WEEKLY }),
+        take: 5,
+      })
+    )
+  })
+
+  it('POST validates required fields', async () => {
+    const response = await POST(
+      new Request('http://localhost/api/schedules', {
+        method: 'POST',
+        body: JSON.stringify({ slotType: Frequency.WEEKLY }),
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toContain('scheduledFor is required')
+  })
+
+  it('POST creates schedule from suggestion when no choreId is provided', async () => {
+    mockGetSuggestedChoreForSlot.mockResolvedValue({
+      chore: { id: 'chore-1' },
+      lastCompletedAt: null,
+      assignedToUser: false,
+    })
+    mockDb.schedule.create.mockResolvedValue({
+      id: 'schedule-1',
+      choreId: 'chore-1',
+      slotType: Frequency.WEEKLY,
+      suggested: true,
+    })
+
+    const response = await POST(
+      new Request('http://localhost/api/schedules', {
+        method: 'POST',
+        body: JSON.stringify({
+          scheduledFor: '2025-01-10T00:00:00.000Z',
+          slotType: Frequency.WEEKLY,
+        }),
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(body.data.suggested).toBe(true)
+    expect(mockGetSuggestedChoreForSlot).toHaveBeenCalledWith(Frequency.WEEKLY, undefined)
+  })
+
+  it('POST validates manual chore compatibility', async () => {
+    mockDb.chore.findUnique.mockResolvedValue({ id: 'chore-1', frequency: Frequency.YEARLY })
+    mockIsChoreCompatibleWithSlot.mockReturnValue(false)
+
+    const response = await POST(
+      new Request('http://localhost/api/schedules', {
+        method: 'POST',
+        body: JSON.stringify({
+          scheduledFor: '2025-01-10T00:00:00.000Z',
+          slotType: Frequency.WEEKLY,
+          choreId: 'chore-1',
+        }),
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toContain('not compatible')
+  })
+
+  it('POST creates schedule with provided choreId', async () => {
+    mockDb.chore.findUnique.mockResolvedValue({ id: 'chore-1', frequency: Frequency.DAILY })
+    mockDb.schedule.create.mockResolvedValue({
+      id: 'schedule-1',
+      choreId: 'chore-1',
+      slotType: Frequency.WEEKLY,
+      suggested: false,
+    })
+
+    const response = await POST(
+      new Request('http://localhost/api/schedules', {
+        method: 'POST',
+        body: JSON.stringify({
+          scheduledFor: '2025-01-10T00:00:00.000Z',
+          slotType: Frequency.WEEKLY,
+          choreId: 'chore-1',
+          suggested: false,
+        }),
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(body.data.choreId).toBe('chore-1')
+    expect(mockDb.schedule.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          choreId: 'chore-1',
+          suggested: false,
+        }),
+      })
+    )
+  })
+})

--- a/web/app/api/schedules/route.ts
+++ b/web/app/api/schedules/route.ts
@@ -1,0 +1,209 @@
+import { Frequency } from '@prisma/client'
+import { requireApprovedUser } from '@/lib/auth/require-approval'
+import { db } from '@/lib/db'
+import { getSuggestedChoreForSlot, isChoreCompatibleWithSlot } from '@/lib/suggestions'
+
+interface CreateSchedulePayload {
+  scheduledFor?: unknown
+  slotType?: unknown
+  choreId?: unknown
+  suggested?: unknown
+  userId?: unknown
+}
+
+function isFrequency(value: string): value is Frequency {
+  return value === 'DAILY' || value === 'WEEKLY' || value === 'MONTHLY' || value === 'YEARLY'
+}
+
+export async function GET(request: Request) {
+  await requireApprovedUser()
+
+  const { searchParams } = new URL(request.url)
+
+  const from = searchParams.get('from')
+  const to = searchParams.get('to')
+  const slotType = searchParams.get('slotType')
+  const userId = searchParams.get('userId')
+  const limitRaw = searchParams.get('limit')
+
+  const where: {
+    slotType?: Frequency
+    scheduledFor?: {
+      gte?: Date
+      lte?: Date
+    }
+    chore?: {
+      assignments: {
+        some: {
+          userId: string
+        }
+      }
+    }
+  } = {}
+
+  if (slotType) {
+    if (!isFrequency(slotType)) {
+      return Response.json({ error: 'Invalid slotType' }, { status: 400 })
+    }
+    where.slotType = slotType
+  }
+
+  if (from || to) {
+    where.scheduledFor = {}
+
+    if (from) {
+      const fromDate = new Date(from)
+      if (Number.isNaN(fromDate.getTime())) {
+        return Response.json({ error: 'Invalid from date' }, { status: 400 })
+      }
+      where.scheduledFor.gte = fromDate
+    }
+
+    if (to) {
+      const toDate = new Date(to)
+      if (Number.isNaN(toDate.getTime())) {
+        return Response.json({ error: 'Invalid to date' }, { status: 400 })
+      }
+      where.scheduledFor.lte = toDate
+    }
+  }
+
+  if (userId) {
+    where.chore = {
+      assignments: {
+        some: {
+          userId,
+        },
+      },
+    }
+  }
+
+  const limit = limitRaw ? Number(limitRaw) : 100
+  if (!Number.isInteger(limit) || limit <= 0 || limit > 500) {
+    return Response.json({ error: 'limit must be an integer between 1 and 500' }, { status: 400 })
+  }
+
+  const schedules = await db.schedule.findMany({
+    where,
+    take: limit,
+    orderBy: {
+      scheduledFor: 'asc',
+    },
+    include: {
+      chore: {
+        include: {
+          assignments: {
+            include: {
+              user: {
+                select: {
+                  id: true,
+                  name: true,
+                  image: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      completions: {
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              image: true,
+            },
+          },
+        },
+      },
+    },
+  })
+
+  return Response.json({ data: schedules })
+}
+
+export async function POST(request: Request) {
+  await requireApprovedUser()
+
+  let payload: CreateSchedulePayload
+  try {
+    payload = (await request.json()) as CreateSchedulePayload
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const scheduledForRaw = typeof payload.scheduledFor === 'string' ? payload.scheduledFor : ''
+  const slotTypeRaw = typeof payload.slotType === 'string' ? payload.slotType : ''
+  const choreId = typeof payload.choreId === 'string' ? payload.choreId.trim() : ''
+  const userId = typeof payload.userId === 'string' ? payload.userId.trim() : ''
+
+  if (!scheduledForRaw) {
+    return Response.json({ error: 'scheduledFor is required' }, { status: 400 })
+  }
+
+  const scheduledFor = new Date(scheduledForRaw)
+  if (Number.isNaN(scheduledFor.getTime())) {
+    return Response.json({ error: 'scheduledFor must be a valid date' }, { status: 400 })
+  }
+
+  if (!isFrequency(slotTypeRaw)) {
+    return Response.json({ error: 'slotType must be DAILY, WEEKLY, MONTHLY, or YEARLY' }, { status: 400 })
+  }
+
+  let finalChoreId = choreId
+  let suggested = false
+
+  if (!finalChoreId) {
+    const suggestion = await getSuggestedChoreForSlot(slotTypeRaw, userId || undefined)
+    if (!suggestion) {
+      return Response.json({ error: 'No compatible chore found for this slot' }, { status: 404 })
+    }
+
+    finalChoreId = suggestion.chore.id
+    suggested = true
+  } else {
+    const chore = await db.chore.findUnique({
+      where: { id: finalChoreId },
+      select: { id: true, frequency: true },
+    })
+
+    if (!chore) {
+      return Response.json({ error: 'Chore not found' }, { status: 404 })
+    }
+
+    if (!isChoreCompatibleWithSlot(chore.frequency, slotTypeRaw)) {
+      return Response.json({ error: 'Chore frequency is not compatible with this slot type' }, { status: 400 })
+    }
+
+    suggested = payload.suggested === true
+  }
+
+  const schedule = await db.schedule.create({
+    data: {
+      choreId: finalChoreId,
+      slotType: slotTypeRaw,
+      scheduledFor,
+      suggested,
+    },
+    include: {
+      chore: {
+        include: {
+          assignments: {
+            include: {
+              user: {
+                select: {
+                  id: true,
+                  name: true,
+                  image: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      completions: true,
+    },
+  })
+
+  return Response.json({ data: schedule }, { status: 201 })
+}

--- a/web/app/api/schedules/suggest/__tests__/route.test.ts
+++ b/web/app/api/schedules/suggest/__tests__/route.test.ts
@@ -1,0 +1,76 @@
+/** @jest-environment node */
+
+import { Frequency } from '@prisma/client'
+import { POST } from '../route'
+import { requireApprovedUser } from '@/lib/auth/require-approval'
+import { getSuggestedChoreForSlot } from '@/lib/suggestions'
+
+jest.mock('@/lib/auth/require-approval', () => ({
+  requireApprovedUser: jest.fn(),
+}))
+
+jest.mock('@/lib/suggestions', () => ({
+  getSuggestedChoreForSlot: jest.fn(),
+}))
+
+const mockRequireApprovedUser = requireApprovedUser as jest.Mock
+const mockGetSuggestedChoreForSlot = getSuggestedChoreForSlot as jest.Mock
+
+describe('/api/schedules/suggest', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRequireApprovedUser.mockResolvedValue({ user: { id: 'user-1' } })
+  })
+
+  it('validates slotType', async () => {
+    const response = await POST(
+      new Request('http://localhost/api/schedules/suggest', {
+        method: 'POST',
+        body: JSON.stringify({ slotType: 'INVALID' }),
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toContain('slotType must be')
+  })
+
+  it('returns 404 when no suggestion is available', async () => {
+    mockGetSuggestedChoreForSlot.mockResolvedValue(null)
+
+    const response = await POST(
+      new Request('http://localhost/api/schedules/suggest', {
+        method: 'POST',
+        body: JSON.stringify({ slotType: Frequency.MONTHLY }),
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(body.error).toContain('No compatible chores')
+  })
+
+  it('returns a suggestion payload', async () => {
+    mockGetSuggestedChoreForSlot.mockResolvedValue({
+      chore: { id: 'chore-1', title: 'Deep clean oven' },
+      lastCompletedAt: null,
+      assignedToUser: true,
+    })
+
+    const response = await POST(
+      new Request('http://localhost/api/schedules/suggest', {
+        method: 'POST',
+        body: JSON.stringify({ slotType: Frequency.MONTHLY, userId: 'user-1' }),
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.data.chore.id).toBe('chore-1')
+    expect(body.data.assignedToUser).toBe(true)
+    expect(mockGetSuggestedChoreForSlot).toHaveBeenCalledWith(Frequency.MONTHLY, 'user-1')
+  })
+})

--- a/web/app/api/schedules/suggest/route.ts
+++ b/web/app/api/schedules/suggest/route.ts
@@ -1,0 +1,44 @@
+import { Frequency } from '@prisma/client'
+import { requireApprovedUser } from '@/lib/auth/require-approval'
+import { getSuggestedChoreForSlot } from '@/lib/suggestions'
+
+interface SuggestPayload {
+  slotType?: unknown
+  userId?: unknown
+}
+
+function isFrequency(value: string): value is Frequency {
+  return value === 'DAILY' || value === 'WEEKLY' || value === 'MONTHLY' || value === 'YEARLY'
+}
+
+export async function POST(request: Request) {
+  await requireApprovedUser()
+
+  let payload: SuggestPayload
+  try {
+    payload = (await request.json()) as SuggestPayload
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const slotType = typeof payload.slotType === 'string' ? payload.slotType : ''
+  const userId = typeof payload.userId === 'string' ? payload.userId.trim() : ''
+
+  if (!isFrequency(slotType)) {
+    return Response.json({ error: 'slotType must be DAILY, WEEKLY, MONTHLY, or YEARLY' }, { status: 400 })
+  }
+
+  const suggestion = await getSuggestedChoreForSlot(slotType, userId || undefined)
+  if (!suggestion) {
+    return Response.json({ error: 'No compatible chores available for this slot type' }, { status: 404 })
+  }
+
+  return Response.json({
+    data: {
+      slotType,
+      chore: suggestion.chore,
+      lastCompletedAt: suggestion.lastCompletedAt,
+      assignedToUser: suggestion.assignedToUser,
+    },
+  })
+}

--- a/web/docs/PHASE_4_SUMMARY.md
+++ b/web/docs/PHASE_4_SUMMARY.md
@@ -1,0 +1,62 @@
+# Phase 4 (v0.4.0) - Suggestion Algorithm & Schedules
+
+## Completed Features
+
+1. Implemented slot-based task suggestion engine in `lib/suggestions.ts`.
+2. Added compatibility rules for slot/chore frequencies.
+3. Implemented schedules API:
+   - `GET /api/schedules`
+   - `POST /api/schedules`
+   - `DELETE /api/schedules/[id]`
+   - `POST /api/schedules/suggest`
+4. Added comprehensive unit tests for the suggestion algorithm and schedule APIs.
+
+## File Structure
+
+### New Core Logic
+- `lib/suggestions.ts`
+- `lib/__tests__/suggestions.test.ts`
+
+### New API Routes
+- `app/api/schedules/route.ts`
+- `app/api/schedules/[id]/route.ts`
+- `app/api/schedules/suggest/route.ts`
+
+### New API Tests
+- `app/api/schedules/__tests__/route.test.ts`
+- `app/api/schedules/[id]/__tests__/route.test.ts`
+- `app/api/schedules/suggest/__tests__/route.test.ts`
+
+### Docs
+- `docs/PHASE_4_SUMMARY.md`
+
+## Key Implementation Details
+
+1. Weekly slots pull from `DAILY` + `MONTHLY`; monthly slots pull from `YEARLY`.
+2. Suggestion ranking order:
+   - Never-completed chores first
+   - Least recently completed next
+   - Assignment-to-user as a tiebreaker
+3. Schedule creation supports both:
+   - Auto-suggested chore assignment
+   - Manual chore selection with compatibility validation
+4. `GET /api/schedules` supports filtering by date range, slot type, assigned user, and limit.
+
+## Database Changes
+
+No schema changes were required in this phase.
+
+## Testing Status
+
+- [x] Suggestion compatibility and ranking tests
+- [x] Schedule list/create/delete route tests
+- [x] Suggestion endpoint tests
+
+## Known Limitations
+
+1. Suggestion endpoint currently returns a single best match only.
+2. Schedule filtering by `userId` uses assignment relation and does not include unassigned chores.
+
+## Next Steps
+
+Proceed to Phase 5: dashboard and main UI implementation.

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -13,6 +13,7 @@ const customJestConfig = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },
+  modulePathIgnorePatterns: ['<rootDir>/.next/'],
   testMatch: [
     '**/__tests__/**/*.[jt]s?(x)',
     '**/?(*.)+(spec|test).[jt]s?(x)',

--- a/web/lib/__tests__/suggestions.test.ts
+++ b/web/lib/__tests__/suggestions.test.ts
@@ -1,0 +1,127 @@
+/** @jest-environment node */
+
+import { Frequency } from '@prisma/client'
+import {
+  getCompatibleFrequencies,
+  getSuggestedChoreForSlot,
+  isChoreCompatibleWithSlot,
+  isSlotTypeSupported,
+} from '../suggestions'
+import { db } from '@/lib/db'
+
+jest.mock('@/lib/db', () => ({
+  db: {
+    chore: {
+      findMany: jest.fn(),
+    },
+  },
+}))
+
+type MockDb = {
+  chore: {
+    findMany: jest.Mock
+  }
+}
+
+const mockDb = db as unknown as MockDb
+
+describe('suggestions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns slot compatibility rules', () => {
+    expect(getCompatibleFrequencies(Frequency.WEEKLY)).toEqual([Frequency.DAILY, Frequency.MONTHLY])
+    expect(getCompatibleFrequencies(Frequency.MONTHLY)).toEqual([Frequency.YEARLY])
+    expect(getCompatibleFrequencies(Frequency.YEARLY)).toEqual([])
+  })
+
+  it('checks supported slot types and compatibility', () => {
+    expect(isSlotTypeSupported(Frequency.WEEKLY)).toBe(true)
+    expect(isSlotTypeSupported(Frequency.YEARLY)).toBe(false)
+    expect(isChoreCompatibleWithSlot(Frequency.DAILY, Frequency.WEEKLY)).toBe(true)
+    expect(isChoreCompatibleWithSlot(Frequency.YEARLY, Frequency.WEEKLY)).toBe(false)
+  })
+
+  it('prioritizes never-completed chores', async () => {
+    mockDb.chore.findMany.mockResolvedValue([
+      {
+        id: 'chore-1',
+        title: 'Old completed chore',
+        frequency: Frequency.DAILY,
+        assignments: [],
+        completions: [{ completedAt: new Date('2025-01-01T00:00:00.000Z') }],
+      },
+      {
+        id: 'chore-2',
+        title: 'Never completed chore',
+        frequency: Frequency.DAILY,
+        assignments: [],
+        completions: [],
+      },
+    ])
+
+    const suggestion = await getSuggestedChoreForSlot(Frequency.WEEKLY)
+
+    expect(suggestion?.chore.id).toBe('chore-2')
+    expect(suggestion?.lastCompletedAt).toBeNull()
+  })
+
+  it('falls back to least-recently completed when all have history', async () => {
+    mockDb.chore.findMany.mockResolvedValue([
+      {
+        id: 'chore-1',
+        title: 'Recently completed',
+        frequency: Frequency.DAILY,
+        assignments: [],
+        completions: [{ completedAt: new Date('2025-01-05T00:00:00.000Z') }],
+      },
+      {
+        id: 'chore-2',
+        title: 'Least recently completed',
+        frequency: Frequency.DAILY,
+        assignments: [],
+        completions: [{ completedAt: new Date('2025-01-02T00:00:00.000Z') }],
+      },
+    ])
+
+    const suggestion = await getSuggestedChoreForSlot(Frequency.WEEKLY)
+
+    expect(suggestion?.chore.id).toBe('chore-2')
+  })
+
+  it('uses assignment matching as tiebreaker for same completion age', async () => {
+    const completionDate = new Date('2025-01-02T00:00:00.000Z')
+
+    mockDb.chore.findMany.mockResolvedValue([
+      {
+        id: 'chore-1',
+        title: 'Unassigned',
+        frequency: Frequency.DAILY,
+        assignments: [],
+        completions: [{ completedAt: completionDate }],
+      },
+      {
+        id: 'chore-2',
+        title: 'Assigned',
+        frequency: Frequency.DAILY,
+        assignments: [{ userId: 'user-1' }],
+        completions: [{ completedAt: completionDate }],
+      },
+    ])
+
+    const suggestion = await getSuggestedChoreForSlot(Frequency.WEEKLY, 'user-1')
+
+    expect(suggestion?.chore.id).toBe('chore-2')
+    expect(suggestion?.assignedToUser).toBe(true)
+  })
+
+  it('returns null for unsupported slot types or empty pools', async () => {
+    const yearlySuggestion = await getSuggestedChoreForSlot(Frequency.YEARLY)
+    expect(yearlySuggestion).toBeNull()
+
+    mockDb.chore.findMany.mockResolvedValue([])
+    const noChoreSuggestion = await getSuggestedChoreForSlot(Frequency.MONTHLY)
+    expect(noChoreSuggestion).toBeNull()
+  })
+})

--- a/web/lib/suggestions.ts
+++ b/web/lib/suggestions.ts
@@ -1,0 +1,114 @@
+import { Frequency, Prisma } from '@prisma/client'
+import { db } from '@/lib/db'
+
+const SLOT_COMPATIBILITY: Record<Frequency, Frequency[]> = {
+  DAILY: [],
+  WEEKLY: [Frequency.DAILY, Frequency.MONTHLY],
+  MONTHLY: [Frequency.YEARLY],
+  YEARLY: [],
+}
+
+export interface SuggestedChoreResult {
+  chore: Prisma.ChoreGetPayload<{
+    include: {
+      assignments: {
+        select: {
+          userId: true
+        }
+      }
+      completions: {
+        select: {
+          completedAt: true
+        }
+      }
+    }
+  }>
+  lastCompletedAt: Date | null
+  assignedToUser: boolean
+}
+
+export function getCompatibleFrequencies(slotType: Frequency): Frequency[] {
+  return SLOT_COMPATIBILITY[slotType]
+}
+
+export function isSlotTypeSupported(slotType: Frequency): boolean {
+  return getCompatibleFrequencies(slotType).length > 0
+}
+
+export function isChoreCompatibleWithSlot(choreFrequency: Frequency, slotType: Frequency): boolean {
+  return getCompatibleFrequencies(slotType).includes(choreFrequency)
+}
+
+export async function getSuggestedChoreForSlot(
+  slotType: Frequency,
+  userId?: string | null
+): Promise<SuggestedChoreResult | null> {
+  if (!isSlotTypeSupported(slotType)) {
+    return null
+  }
+
+  const compatibleFrequencies = getCompatibleFrequencies(slotType)
+
+  const chores = await db.chore.findMany({
+    where: {
+      frequency: {
+        in: compatibleFrequencies,
+      },
+    },
+    include: {
+      assignments: {
+        select: {
+          userId: true,
+        },
+      },
+      completions: {
+        select: {
+          completedAt: true,
+        },
+        orderBy: {
+          completedAt: 'desc',
+        },
+        take: 1,
+      },
+    },
+  })
+
+  if (chores.length === 0) {
+    return null
+  }
+
+  const rankedChores: SuggestedChoreResult[] = chores.map((chore) => {
+    const lastCompletedAt = chore.completions[0]?.completedAt ?? null
+    const assignedToUser = userId ? chore.assignments.some((assignment) => assignment.userId === userId) : false
+
+    return {
+      chore,
+      lastCompletedAt,
+      assignedToUser,
+    }
+  })
+
+  rankedChores.sort((left, right) => {
+    const leftNeverCompleted = left.lastCompletedAt === null
+    const rightNeverCompleted = right.lastCompletedAt === null
+
+    if (leftNeverCompleted !== rightNeverCompleted) {
+      return leftNeverCompleted ? -1 : 1
+    }
+
+    if (left.lastCompletedAt && right.lastCompletedAt) {
+      const completionDifference = left.lastCompletedAt.getTime() - right.lastCompletedAt.getTime()
+      if (completionDifference !== 0) {
+        return completionDifference
+      }
+    }
+
+    if (userId && left.assignedToUser !== right.assignedToUser) {
+      return left.assignedToUser ? -1 : 1
+    }
+
+    return left.chore.title.localeCompare(right.chore.title)
+  })
+
+  return rankedChores[0] ?? null
+}


### PR DESCRIPTION
## Summary\n- add slot-based suggestion engine with compatibility and ranking rules\n- add schedules API endpoints for list/create/delete\n- add /api/schedules/suggest endpoint\n- add unit tests for suggestion logic and schedule routes\n- add Phase 4 summary documentation\n\n## Validation\n- npm run lint\n- npm run test\n- npm run build